### PR TITLE
eth_api: Implement protocol_version method

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -1580,7 +1580,7 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
     }
 
     fn protocol_version(&self) -> jsonrpc_core::BoxFuture<jsonrpc_core::Result<String>> {
-        not_implemented("protocol_version")
+        Ok("zks/1".to_string()).into_boxed_future()
     }
 
     fn syncing(


### PR DESCRIPTION
few points:
 - `eth_protocolVersion` was [removed from geth](https://github.com/ethereum/go-ethereum/pull/22064), is it actually needed?
 - the spec appears to be wrong- in geth and the existing handler stub it returns `String`, however the ticket states `U256`
 - what does 'protocol version' even mean in this context? the suggested string `zks/1` appears nowhere in the codebase, perhaps we should add it as a constant?