### PR TITLE
returns blocks via hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,9 +884,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "bstr"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
 dependencies = [
  "memchr",
  "serde",
@@ -1773,6 +1784,7 @@ dependencies = [
  "eyre",
  "futures 0.3.28",
  "hex",
+ "httptest",
  "itertools",
  "jsonrpc-core 18.0.0 (git+https://github.com/matter-labs/jsonrpc.git?branch=master)",
  "jsonrpc-core-client",
@@ -2312,7 +2324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
 dependencies = [
  "aho-corasick",
- "bstr",
+ "bstr 1.6.2",
  "fnv",
  "log",
  "regex",
@@ -2691,6 +2703,28 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httptest"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f25cfb6def593d43fae1ead24861f217e93bc70768a45cc149a69b5f049df4"
+dependencies = [
+ "bstr 0.2.17",
+ "bytes 1.4.0",
+ "crossbeam-channel 0.5.8",
+ "form_urlencoded",
+ "futures 0.3.28",
+ "http",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
 
 [[package]]
 name = "humantime"
@@ -3453,9 +3487,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ bigdecimal = { version = "0.2.0" }
 hex = "0.4"
 ethabi = "16.0.0"
 itertools = "0.10.5"
+
+[dev-dependencies]
+httptest = "0.15.4"

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -216,6 +216,7 @@ pub struct ForkDetails<S> {
     // Block number at which we forked (the next block to create is l1_block + 1)
     pub l1_block: L1BatchNumber,
     pub l2_miniblock: u64,
+    pub l2_miniblock_hash: Option<H256>,
     pub block_timestamp: u64,
     pub overwrite_chain_id: Option<L2ChainId>,
     pub l1_gas_price: u64,
@@ -248,6 +249,7 @@ impl ForkDetails<HttpForkSource> {
             l1_block: l1_batch_number,
             block_timestamp: block_details.base.timestamp,
             l2_miniblock: miniblock,
+            l2_miniblock_hash: block_details.base.root_hash,
             overwrite_chain_id: chain_id,
             l1_gas_price: block_details.base.l1_gas_price,
         }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -14,7 +14,7 @@ use tokio::runtime::Builder;
 use zksync_basic_types::{Address, L1BatchNumber, L2ChainId, MiniblockNumber, H256, U256, U64};
 
 use zksync_types::{
-    api::{BlockIdVariant, BlockNumber, Transaction},
+    api::{Block, BlockIdVariant, BlockNumber, Transaction, TransactionVariant},
     l2::L2Tx,
     StorageKey,
 };
@@ -205,6 +205,13 @@ pub trait ForkSource {
         &self,
         block_number: MiniblockNumber,
     ) -> eyre::Result<Vec<zksync_types::Transaction>>;
+
+    /// Returns the block for a given hash.
+    fn get_block_by_hash(
+        &self,
+        hash: H256,
+        full_transactions: bool,
+    ) -> eyre::Result<Option<Block<TransactionVariant>>>;
 }
 
 /// Holds the information about the original chain.

--- a/src/http_fork_source.rs
+++ b/src/http_fork_source.rs
@@ -59,4 +59,14 @@ impl ForkSource for HttpForkSource {
         block_on(async move { client.get_raw_block_transactions(block_number).await })
             .wrap_err("fork http client failed")
     }
+
+    fn get_block_by_hash(
+        &self,
+        hash: zksync_basic_types::H256,
+        full_transactions: bool,
+    ) -> eyre::Result<Option<zksync_types::api::Block<zksync_types::api::TransactionVariant>>> {
+        let client = self.create_client();
+        block_on(async move { client.get_block_by_hash(hash, full_transactions).await })
+            .wrap_err("fork http client failed")
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,5 @@ pub mod node;
 pub mod resolver;
 pub mod utils;
 pub mod zks;
+
+mod testing;

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ mod formatter;
 mod http_fork_source;
 mod node;
 mod resolver;
+mod testing;
 mod utils;
 mod zks;
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -1415,8 +1415,8 @@ impl<S: Send + Sync + 'static + ForkSource + std::fmt::Debug> EthNamespaceT for 
 
                 writer
                     .block_hashes
-                    .insert(matching_block.batch_number, hash.clone());
-                writer.blocks.insert(hash.clone(), matching_block.clone());
+                    .insert(matching_block.batch_number, hash);
+                writer.blocks.insert(hash, matching_block.clone());
             }
 
             let block = zksync_types::api::Block {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -2,6 +2,7 @@
 //!
 //! There is MockServer that can help simulate a forked network.
 //!
+
 #![cfg(test)]
 
 use httptest::{

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,101 @@
+//! This file hold testing helpers for other unit tests.
+//!
+//! There is MockServer that can help simulate a forked network.
+//!
+#![cfg(test)]
+
+use httptest::{
+    matchers::{eq, json_decoded, request},
+    responders::json_encoded,
+    Expectation, Server,
+};
+
+/// A HTTP server that can be used to mock a fork source.
+pub struct MockServer {
+    /// The implementation for [httptest::Server].
+    pub inner: Server,
+}
+
+impl MockServer {
+    /// Start the mock server with pre-defined calls used to fetch the fork's state.
+    pub fn run() -> Self {
+        let server = Server::run();
+
+        // setup initial fork calls
+        server.expect(
+            Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "eth_blockNumber",
+            })))))
+            .respond_with(json_encoded(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "result": "0xa",
+            }))),
+        );
+        server.expect(
+            Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "zks_getBlockDetails",
+                "params": vec![ 10 ],
+            })))))
+            .respond_with(json_encoded(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "number": 10,
+                    "l1BatchNumber": 5,
+                    "timestamp": 1676461082u64,
+                    "l1TxCount": 0,
+                    "l2TxCount": 0,
+                    "rootHash": "0x086c9487350539c884510044efce5e3f2aaffca4215c12b9044506375097fecd",
+                    "status": "verified",
+                    "commitTxHash": "0x9f5b07e968787514667fae74e77ecab766be42acd602c85cfdbda1dc3dd9902f",
+                    "committedAt": "2023-02-15T11:40:39.326104Z",
+                    "proveTxHash": "0xac8fe9fdcbeb5f1e59c41e6bd33b75d405af84e4b968cd598c2d3f59c9c925c8",
+                    "provenAt": "2023-02-15T12:42:40.073918Z",
+                    "executeTxHash": "0x65d50174b214b05e82936c4064023cbea5f6f8135e30b4887986b316a2178a39",
+                    "executedAt": "2023-02-15T12:43:20.330052Z",
+                    "l1GasPrice": 29860969933u64,
+                    "l2FairGasPrice": 500000000u64,
+                    "baseSystemContractsHashes": {
+                      "bootloader": "0x0100038581be3d0e201b3cc45d151ef5cc59eb3a0f146ad44f0f72abf00b594c",
+                      "default_aa": "0x0100038dc66b69be75ec31653c64cb931678299b9b659472772b2550b703f41c"
+                    },
+                    "operatorAddress": "0xfeee860e7aae671124e9a4e61139f3a5085dfeee",
+                    "protocolVersion": null
+                  },
+            }))),
+        );
+        server.expect(
+            Expectation::matching(request::body(json_decoded(eq(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "eth_getStorageAt",
+                "params": vec!["0x000000000000000000000000000000000000800a","0xe9472b134a1b5f7b935d5debff2691f95801214eafffdeabbf0e366da383104e","0xa"],
+            }))))).times(0..)
+            .respond_with(json_encoded(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "result": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            }))),
+        );
+
+        MockServer { inner: server }
+    }
+
+    /// Retrieve the mock server's url.
+    pub fn url(&self) -> String {
+        self.inner.url("").to_string()
+    }
+
+    /// Assert an exactly single call expectation with a given request and the provided response.
+    pub fn expect(&self, request: serde_json::Value, response: serde_json::Value) {
+        self.inner.expect(
+            Expectation::matching(request::body(json_decoded(eq(request))))
+                .respond_with(json_encoded(response)),
+        );
+    }
+}


### PR DESCRIPTION
# What :computer: 

* Adds a concept of block hash for the test node. The block hash is computed as a `keccak256` of the `block_number` and the `tx_hash`.
* Fixes the behavior of `eth_getBlockByHash` to now return a block via its hash. Previously the hash was matched with a transaction instead. 
* Allows fetching for historical blocks over network if a fork source has been specified. The block is cached for any subsequent requests.

 Why :hand:
* Users of the test node can now expect the correct behavior when they call `eth_getBlockByHash`.
* Any missing historical blocks are now fetched and cached if a fork source has been provided. This aligns with the user expectations for this method call.
* The block specification of the test node is now more consistent with having an appropriate block hash, which is in line with user expectations.

# Evidence :camera:
Passing unit tests:
![image](https://github.com/Moonsong-Labs/era-test-node/assets/1564843/eb13425c-c2f7-46b3-8561-6a9bee7bf91d)


# Notes :memo:

Fixes #25