### PR TITLE
add index.html to docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,6 +35,21 @@ jobs:
         run: |
           echo "Generating docs..."
           cargo doc --no-deps
+      - name: Make index.html
+        run: echo '<!DOCTYPE HTML>
+          <html lang="en-US">
+              <head>
+                  <meta charset="UTF-8">
+                  <meta http-equiv="refresh" content="0; url=./era_test_node/index.html">
+                  <script type="text/javascript">
+                      window.location.href = "./era_test_node/index.html"
+                  </script>
+                  <title>Page Redirection</title>
+              </head>
+              <body>
+                  If you are not redirected automatically, follow this <a href='./era_test_node/index.html'>link to example</a>.
+              </body>
+          </html>' > ./target/doc/index.html
       - name: Fix permissions
         run: |
           chmod -c -R +rX "target/doc/" | while read line; do

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,7 +3,7 @@ name: Deploy static content to Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "nish-fix-82"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/src/deps/mod.rs
+++ b/src/deps/mod.rs
@@ -113,7 +113,7 @@ pub trait ReadStorage: fmt::Debug {
 
 /// Functionality to write to the VM storage in a batch.
 ///
-/// So far, this trait is implemented only for [`StorageView`].
+/// So far, this trait is implemented only for [`zksync_state::StorageView`].
 pub trait WriteStorage: ReadStorage {
     /// Sets the new value under a given key and returns the previous value.
     fn set_value(&mut self, key: StorageKey, value: StorageValue) -> StorageValue;


### PR DESCRIPTION
# What :computer: 
* Adds `index.html` to the generated docs directory.

# Why :hand:
* Allows users to directly land on the documentation page instead of getting a `404` error.

# Evidence :camera:

