### PR TITLE
feat: add vm store cheatcode

### DIFF
--- a/e2e-tests/contracts/TestCheatcodes.sol
+++ b/e2e-tests/contracts/TestCheatcodes.sol
@@ -54,10 +54,26 @@ contract TestCheatcodes {
     require(finalTimestamp == timestamp, "timestamp was not changed");
   }
 
-  function testStore(address account, bytes32 slot, bytes32 value) external {
+  function testStore(bytes32 slot, bytes32 value) external {
+    testStoreTarget testStoreInstance = new testStoreTarget();
+
     (bool success, ) = CHEATCODE_ADDRESS.call(
-      abi.encodeWithSignature("store(address,bytes32,bytes32)", account, slot, value)
+      abi.encodeWithSignature("store(address,bytes32,bytes32)", address(testStoreInstance), slot, value)
     );
+
+    testStoreInstance.testStoredValue();
     require(success, "store failed");
+      
   }
+}
+
+contract testStoreTarget {
+  bytes32 public testValue = bytes32(uint256(0)); //slot 0
+
+  function testStoredValue() public view {
+    require(
+      testValue == bytes32(uint256(0)),
+      "testValue was not stored correctly"
+    );
+  } 
 }

--- a/e2e-tests/contracts/TestCheatcodes.sol
+++ b/e2e-tests/contracts/TestCheatcodes.sol
@@ -63,7 +63,6 @@ contract TestCheatcodes {
 
     testStoreInstance.testStoredValue();
     require(success, "store failed");
-      
   }
 }
 
@@ -71,9 +70,6 @@ contract testStoreTarget {
   bytes32 public testValue = bytes32(uint256(0)); //slot 0
 
   function testStoredValue() public view {
-    require(
-      testValue == bytes32(uint256(0)),
-      "testValue was not stored correctly"
-    );
-  } 
+    require(testValue == bytes32(uint256(115792089237316195423570985008687907853269984665640564039457584007913129639935)), "testValue was not stored correctly");
+  }
 }

--- a/e2e-tests/contracts/TestCheatcodes.sol
+++ b/e2e-tests/contracts/TestCheatcodes.sol
@@ -61,7 +61,7 @@ contract TestCheatcodes {
       abi.encodeWithSignature("store(address,bytes32,bytes32)", address(testStoreInstance), slot, value)
     );
 
-    testStoreInstance.testStoredValue();
+    testStoreInstance.testStoredValue(value);
     require(success, "store failed");
   }
 }
@@ -69,7 +69,7 @@ contract TestCheatcodes {
 contract testStoreTarget {
   bytes32 public testValue = bytes32(uint256(0)); //slot 0
 
-  function testStoredValue() public view {
-    require(testValue == bytes32(uint256(115792089237316195423570985008687907853269984665640564039457584007913129639935)), "testValue was not stored correctly");
+  function testStoredValue(bytes32 value) public view {
+    require(testValue == value, "testValue was not stored correctly");
   }
 }

--- a/e2e-tests/contracts/TestCheatcodes.sol
+++ b/e2e-tests/contracts/TestCheatcodes.sol
@@ -47,4 +47,11 @@ contract TestCheatcodes {
     uint256 finalTimestamp = block.timestamp;
     require(finalTimestamp == timestamp, "timestamp was not changed");
   }
+
+  function testStore(address account, bytes32 slot, bytes32 value) external {
+    (bool success, ) = CHEATCODE_ADDRESS.call(
+      abi.encodeWithSignature("store(address,bytes32,bytes32)", account, slot, value)
+    );
+    require(success, "store failed");
+  }
 }

--- a/e2e-tests/test/cheatcodes.test.ts
+++ b/e2e-tests/test/cheatcodes.test.ts
@@ -4,8 +4,6 @@ import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { RichAccounts } from "../helpers/constants";
 import { deployContract, getTestProvider } from "../helpers/utils";
-import { formatBytes32String, hexValue, parseBytes32String, randomBytes } from "ethers/lib/utils";
-import { constants } from "buffer";
 
 const provider = getTestProvider();
 
@@ -125,5 +123,4 @@ describe("Cheatcodes", function () {
     // Assert
     expect(receipt.status).to.eq(1);
   });
-
 });

--- a/e2e-tests/test/cheatcodes.test.ts
+++ b/e2e-tests/test/cheatcodes.test.ts
@@ -4,6 +4,7 @@ import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { RichAccounts } from "../helpers/constants";
 import { deployContract, getTestProvider } from "../helpers/utils";
+import { hexValue, randomBytes } from "ethers/lib/utils";
 
 const provider = getTestProvider();
 
@@ -105,4 +106,26 @@ describe("Cheatcodes", function () {
     const newBlockTimestamp = (await provider.getBlock("latest")).timestamp;
     expect(newBlockTimestamp).to.equal(expectedTimestamp);
   });
+
+  it("Should test vm.store", async function () {
+    // Arrange
+    const wallet = new Wallet(RichAccounts[0].PrivateKey);
+    const deployer = new Deployer(hre, wallet);
+    const randomWallet = Wallet.createRandom().connect(provider);
+
+    // Act
+    const cheatcodes = await deployContract(deployer, "TestCheatcodes", []);
+    const randomSlot = randomBytes(32);
+    const randomValue = randomBytes(32);
+    const tx = await cheatcodes.testStore(randomWallet.address, randomSlot, randomValue, {
+      gasLimit: 1000000,
+    });
+    const receipt = await tx.wait();
+
+    // Assert
+    expect(receipt.status).to.eq(1);
+    const slotValue = (await provider.getStorageAt(randomWallet.address, hexValue(randomSlot)));
+    expect(slotValue).to.eq(hexValue(randomValue));
+  });
+
 });

--- a/e2e-tests/test/cheatcodes.test.ts
+++ b/e2e-tests/test/cheatcodes.test.ts
@@ -4,7 +4,8 @@ import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import { RichAccounts } from "../helpers/constants";
 import { deployContract, getTestProvider } from "../helpers/utils";
-import { hexValue, randomBytes } from "ethers/lib/utils";
+import { formatBytes32String, hexValue, parseBytes32String, randomBytes } from "ethers/lib/utils";
+import { constants } from "buffer";
 
 const provider = getTestProvider();
 
@@ -111,21 +112,18 @@ describe("Cheatcodes", function () {
     // Arrange
     const wallet = new Wallet(RichAccounts[0].PrivateKey);
     const deployer = new Deployer(hre, wallet);
-    const randomWallet = Wallet.createRandom().connect(provider);
 
     // Act
     const cheatcodes = await deployContract(deployer, "TestCheatcodes", []);
-    const randomSlot = randomBytes(32);
-    const randomValue = randomBytes(32);
-    const tx = await cheatcodes.testStore(randomWallet.address, randomSlot, randomValue, {
-      gasLimit: 1000000,
+    const slot = hre.ethers.constants.HashZero;
+    const value = hre.ethers.constants.MaxUint256;
+    const tx = await cheatcodes.testStore(slot, value, {
+      gasLimit: 10000000,
     });
     const receipt = await tx.wait();
 
     // Assert
     expect(receipt.status).to.eq(1);
-    const slotValue = (await provider.getStorageAt(randomWallet.address, hexValue(randomSlot)));
-    expect(slotValue).to.eq(hexValue(randomValue));
   });
 
 });

--- a/src/cheatcodes.rs
+++ b/src/cheatcodes.rs
@@ -2,7 +2,7 @@ use crate::{
     node::{BlockContext, InMemoryNodeInner},
     utils::bytecode_to_factory_dep,
 };
-use ethers::{abi::AbiDecode, prelude::abigen, providers::LogQuery};
+use ethers::{abi::AbiDecode, prelude::abigen};
 use itertools::Itertools;
 use multivm::zk_evm_1_3_3::tracing::AfterExecutionData;
 use multivm::zk_evm_1_3_3::vm_state::PrimitiveValue;
@@ -181,12 +181,14 @@ impl<F: NodeCtx + Send, S: WriteStorage, H: HistoryMode> VmTracer<S, H> for Chea
                 timestamp,
             );
         }
+
         if let Some(start_prank_call) = &self.start_prank_opts {
             let this_address = state.local_state.callstack.current.this_address;
             if !INTERNAL_CONTRACT_ADDRESSES.contains(&this_address) {
                 state.local_state.callstack.current.msg_sender = start_prank_call.sender;
             }
         }
+
         TracerExecutionStatus::Continue
     }
 }

--- a/src/cheatcodes.rs
+++ b/src/cheatcodes.rs
@@ -2,7 +2,7 @@ use crate::{
     node::{BlockContext, InMemoryNodeInner},
     utils::bytecode_to_factory_dep,
 };
-use ethers::{abi::AbiDecode, prelude::abigen};
+use ethers::{abi::AbiDecode, prelude::abigen, providers::LogQuery};
 use itertools::Itertools;
 use multivm::zk_evm_1_3_3::tracing::AfterExecutionData;
 use multivm::zk_evm_1_3_3::vm_state::PrimitiveValue;
@@ -147,6 +147,7 @@ impl<F: NodeCtx + Send, S: WriteStorage, H: HistoryMode> VmTracer<S, H> for Chea
                 timestamp,
             );
         }
+
         TracerExecutionStatus::Continue
     }
 }
@@ -277,7 +278,7 @@ impl<F: NodeCtx> CheatcodeTracer<F> {
                 value,
             }) => {
                 tracing::info!(
-                    "Setting storage slot {:?} for account {:?} to {:?}",
+                    "👷 Setting storage slot {:?} for account {:?} to {:?}",
                     slot,
                     account,
                     value

--- a/src/cheatcodes.rs
+++ b/src/cheatcodes.rs
@@ -49,6 +49,7 @@ abigen!(
         function setNonce(address account, uint64 nonce)
         function roll(uint256 blockNumber)
         function warp(uint256 timestamp)
+        function store(address account, bytes32 slot, bytes32 value)
     ]"#
 );
 
@@ -197,6 +198,21 @@ impl<F: NodeCtx> CheatcodeTracer<F> {
                     key,
                     u256_to_h256(pack_block_info(block_number, timestamp.as_u64())),
                 );
+            }
+            Store(StoreCall {
+                account,
+                slot,
+                value,
+            }) => {
+                tracing::info!(
+                    "Setting storage slot {:?} for account {:?} to {:?}",
+                    slot,
+                    account,
+                    value
+                );
+                let key = StorageKey::new(AccountTreeId::new(account), H256(slot));
+                let mut storage = storage.borrow_mut();
+                storage.set_value(key, H256(value));
             }
         };
     }


### PR DESCRIPTION
# What :computer: 
* Added vm.store cheatcode functionality

# Why :hand:
* downstream users of era-test-node would be able to use sthe store cheatcode to persist a value in a specific slot related to an address in storage. 

# Evidence :camera:
```
function testStore(bytes32 slot, bytes32 value) external {
    testStoreTarget testStoreInstance = new testStoreTarget();

    (bool success, ) = CHEATCODE_ADDRESS.call(
      abi.encodeWithSignature("store(address,bytes32,bytes32)", address(testStoreInstance), slot, value)
    );

    testStoreInstance.testStoredValue();
    require(success, "store failed");
  }
}

contract testStoreTarget {
  bytes32 public testValue = bytes32(uint256(0)); //slot 0

  function testStoredValue() public view {
    require(testValue == bytes32(uint256(115792089237316195423570985008687907853269984665640564039457584007913129639935)), "testValue was not stored correctly");
  }
}
```

Console output
```
  Cheatcodes
    ✔ Should test vm.store (328ms)


  1 passing (335ms)
```

# Notes  📝
When failing assert in function testStoredValue the era-test-node crashes with the following error
```
thread 'tokio-runtime-worker' panicked at 'assertion failed: `(left == right)`
  left: `115792089237316195423570985008687907853269984665640564039457584007913129639935`,
 right: `0`', /Users/jrigada/.cargo/git/checkouts/zksync-era-657998444dcd9ed9/71374c8/core/lib/multivm/src/versions/vm_refunds_enhancement/oracles/storage.rs:400:17
```


