### PR TITLE
feat: add vm load cheatcode

### DIFF
--- a/e2e-tests/contracts/TestCheatcodes.sol
+++ b/e2e-tests/contracts/TestCheatcodes.sol
@@ -147,6 +147,18 @@ contract TestCheatcodes {
     testStoreInstance.testStoredValue(value);
     require(success, "store failed");
   }
+
+  function testLoad(bytes32 slot) external {
+    TestLoadTarget testLoadTarget = new TestLoadTarget();
+    (bool success, bytes memory data) = CHEATCODE_ADDRESS.call(abi.encodeWithSignature("load(address,bytes32)", address(testLoadTarget), slot));
+    require(success, "load failed");
+    bytes32 loadedValue = abi.decode(data, (bytes32));
+    require(loadedValue == bytes32(uint256(1337)), "address mismatch");
+  }
+}
+
+contract TestLoadTarget {
+  bytes32 public testValue = bytes32(uint256(1337)); //slot 0
 }
 
 contract testStoreTarget {

--- a/e2e-tests/test/cheatcodes.test.ts
+++ b/e2e-tests/test/cheatcodes.test.ts
@@ -64,6 +64,23 @@ describe("Cheatcodes", function () {
     expect(finalRandomWalletCode).to.not.eq(initialRandomWalletCode);
   });
 
+  it("Should test vm.load", async function () {
+    // Arrange
+    const wallet = new Wallet(RichAccounts[0].PrivateKey);
+    const deployer = new Deployer(hre, wallet);
+
+    // Act
+    const cheatcodes = await deployContract(deployer, "TestCheatcodes", []);
+    const slot = hre.ethers.constants.HashZero;
+    const tx = await cheatcodes.testLoad(slot, {
+      gasLimit: 10000000,
+    });
+    const receipt = await tx.wait();
+
+    // Assert
+    expect(receipt.status).to.eq(1);
+  });
+
   it("Should test vm.roll", async function () {
     // Arrange
     const wallet = new Wallet(RichAccounts[0].PrivateKey);
@@ -140,6 +157,24 @@ describe("Cheatcodes", function () {
     expect(receipt2.status).to.eq(1);
   });
 
+  it("Should test vm.store", async function () {
+    // Arrange
+    const wallet = new Wallet(RichAccounts[0].PrivateKey);
+    const deployer = new Deployer(hre, wallet);
+
+    // Act
+    const cheatcodes = await deployContract(deployer, "TestCheatcodes", []);
+    const slot = hre.ethers.constants.HashZero;
+    const value = hre.ethers.constants.MaxUint256;
+    const tx = await cheatcodes.testStore(slot, value, {
+      gasLimit: 10000000,
+    });
+    const receipt = await tx.wait();
+
+    // Assert
+    expect(receipt.status).to.eq(1);
+  });
+
   it("Should test vm.warp", async function () {
     // Arrange
     const wallet = new Wallet(RichAccounts[0].PrivateKey);
@@ -161,23 +196,5 @@ describe("Cheatcodes", function () {
     expect(receipt.status).to.eq(1);
     const newBlockTimestamp = (await provider.getBlock("latest")).timestamp;
     expect(newBlockTimestamp).to.equal(expectedTimestamp);
-  });
-
-  it("Should test vm.store", async function () {
-    // Arrange
-    const wallet = new Wallet(RichAccounts[0].PrivateKey);
-    const deployer = new Deployer(hre, wallet);
-
-    // Act
-    const cheatcodes = await deployContract(deployer, "TestCheatcodes", []);
-    const slot = hre.ethers.constants.HashZero;
-    const value = hre.ethers.constants.MaxUint256;
-    const tx = await cheatcodes.testStore(slot, value, {
-      gasLimit: 10000000,
-    });
-    const receipt = await tx.wait();
-
-    // Assert
-    expect(receipt.status).to.eq(1);
   });
 });


### PR DESCRIPTION
# What :computer: 
* Added vm.load cheatcode implementation

# Why :hand:
* downstream users of era-test-node would be able to use the load cheatcode to retrieve a value stored in an specific slot regarding an address. 

# Evidence :camera:
```
  function testLoad(bytes32 slot) external {
    TestLoadTarget testLoadTarget = new TestLoadTarget();
    (bool success, bytes memory data) = CHEATCODE_ADDRESS.call(abi.encodeWithSignature("load(address,bytes32)", address(testLoadTarget), slot));
    require(success, "load failed");
    bytes32 loadedValue = abi.decode(data, (bytes32));
    require(loadedValue == bytes32(uint256(1337)), "address mismatch");
  }
}

contract TestLoadTarget {
  bytes32 public testValue = bytes32(uint256(1337)); //slot 0
}

```
```
Cheatcodes
    ✔ Should test vm.load (429ms)


  1 passing (431ms)

✨  Done in 4.26s.
```
